### PR TITLE
install cargo chef manually

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - chef-fix
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - chef-fix
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM lukemathwalker/cargo-chef:latest-rust-latest AS chef
+FROM rust:latest AS chef
+# We only pay the installation cost once,
+# it will be cached from the second build onwards
+RUN cargo install cargo-chef
 WORKDIR /app
 
 FROM chef AS planner


### PR DESCRIPTION
there is no image for rust 1.88.0 for cargo-chef right now so we'll just install it manually for deployment