### PR TITLE
Support autopilot whitelist masks

### DIFF
--- a/src/commands/staff.rs
+++ b/src/commands/staff.rs
@@ -477,7 +477,7 @@ pub async fn whitelist_user<C: Context>(
     sender: &Session,
     args: WhitelistArgs,
 ) -> CommandResult {
-    if !(0..=3).contains(&args.bit) {
+    if !(0..=7).contains(&args.bit) {
         return Ok(Some("Invalid bit.".to_owned()));
     }
 

--- a/src/models/users.rs
+++ b/src/models/users.rs
@@ -9,7 +9,11 @@ pub enum Whitelist {
     None = 0,
     Vanilla = 1,
     Relax = 2,
-    All = 3,
+    VanillaRelax = 3,
+    Autopilot = 4,
+    VanillaAutopilot = 5,
+    RelaxAutopilot = 6,
+    All = 7,
 }
 
 #[derive(Debug)]
@@ -68,7 +72,11 @@ impl TryFrom<i8> for Whitelist {
             0 => Ok(Whitelist::None),
             1 => Ok(Whitelist::Vanilla),
             2 => Ok(Whitelist::Relax),
-            3 => Ok(Whitelist::All),
+            3 => Ok(Whitelist::VanillaRelax),
+            4 => Ok(Whitelist::Autopilot),
+            5 => Ok(Whitelist::VanillaAutopilot),
+            6 => Ok(Whitelist::RelaxAutopilot),
+            7 => Ok(Whitelist::All),
             _ => Err(AppError::InternalServerError("invalid whitelist value")),
         }
     }


### PR DESCRIPTION
Summary:
- decode whitelist mask values 4 through 7 for Autopilot combinations
- allow the staff whitelist command to set masks up to 7

Verification:
- cargo fmt --check
- cargo test
- git diff --check