### PR TITLE
Add chatbot direct message endpoint

### DIFF
--- a/src/api/v1/mod.rs
+++ b/src/api/v1/mod.rs
@@ -12,4 +12,8 @@ pub fn router() -> Router<AppState> {
         .route("/verifiedStatus", get(ripple::verified_status))
         .route("/playerMatchDetails", get(ripple::player_match_details))
         .route("/fokabotMessage", get(ripple::send_chatbot_message))
+        .route(
+            "/fokabotDirectMessage",
+            get(ripple::send_chatbot_direct_message),
+        )
 }

--- a/src/api/v1/ripple.rs
+++ b/src/api/v1/ripple.rs
@@ -4,9 +4,11 @@ use crate::entities::bot;
 use crate::entities::channels::ChannelName;
 use crate::models::ripple::{
     BaseSuccessData, FetchPlayerMatchDetailsArgs, IsOnlineArgs, IsOnlineResponse, IsVerifiedArgs,
-    OnlineUsersResponse, PlayerMatchDetailsResponse, SendChatbotMessageArgs,
+    OnlineUsersResponse, PlayerMatchDetailsResponse, SendChatbotDirectMessageArgs,
+    SendChatbotDirectMessageResponse, SendChatbotDirectMessageResult, SendChatbotMessageArgs,
     VerifiedStatusResponse,
 };
+use crate::repositories::streams::StreamName;
 use crate::settings::AppSettings;
 use crate::usecases::{channels, ripple, sessions, streams, users};
 use axum::Json;
@@ -96,4 +98,52 @@ pub async fn send_chatbot_message(
     };
     streams::broadcast_message(&ctx, msg_stream, ChatMessage(&msg), None, None).await?;
     Ok(Json(Default::default()))
+}
+
+pub async fn send_chatbot_direct_message(
+    ctx: RequestContext,
+    Query(args): Query<SendChatbotDirectMessageArgs>,
+) -> ServiceResponse<SendChatbotDirectMessageResponse> {
+    let settings = AppSettings::get();
+    if args.key != settings.app_ci_key {
+        return Err(AppError::Unauthorized);
+    }
+
+    let recipient_sessions: Vec<_> = sessions::fetch_by_user_id(&ctx, args.user_id)
+        .await?
+        .collect();
+    if recipient_sessions.is_empty() {
+        return Ok(Json(SendChatbotDirectMessageResponse {
+            result: SendChatbotDirectMessageResult {
+                online: false,
+                sent_sessions: 0,
+            },
+            ..Default::default()
+        }));
+    }
+
+    for recipient_session in &recipient_sessions {
+        let msg = IrcMessage {
+            sender: bot::BOT_NAME,
+            sender_id: bot::BOT_ID as _,
+            text: &args.content,
+            recipient: &recipient_session.username,
+        };
+        streams::broadcast_message(
+            &ctx,
+            StreamName::User(recipient_session.session_id),
+            ChatMessage(&msg),
+            None,
+            None,
+        )
+        .await?;
+    }
+
+    Ok(Json(SendChatbotDirectMessageResponse {
+        result: SendChatbotDirectMessageResult {
+            online: true,
+            sent_sessions: recipient_sessions.len(),
+        },
+        ..Default::default()
+    }))
 }

--- a/src/models/ripple.rs
+++ b/src/models/ripple.rs
@@ -28,6 +28,16 @@ pub struct SendChatbotMessageArgs {
     pub content: String,
 }
 
+#[derive(Deserialize)]
+pub struct SendChatbotDirectMessageArgs {
+    #[serde(rename = "k")]
+    pub key: String,
+    #[serde(rename = "to")]
+    pub user_id: i64,
+    #[serde(rename = "msg")]
+    pub content: String,
+}
+
 #[derive(Serialize)]
 pub struct BaseSuccessData {
     pub message: &'static str,
@@ -55,6 +65,19 @@ pub struct OnlineUsersResponse {
     #[serde(flatten)]
     pub base: BaseSuccessData,
     pub result: u64,
+}
+
+#[derive(Default, Serialize)]
+pub struct SendChatbotDirectMessageResult {
+    pub online: bool,
+    pub sent_sessions: usize,
+}
+
+#[derive(Default, Serialize)]
+pub struct SendChatbotDirectMessageResponse {
+    #[serde(flatten)]
+    pub base: BaseSuccessData,
+    pub result: SendChatbotDirectMessageResult,
 }
 
 #[derive(Default, Serialize)]


### PR DESCRIPTION
## Summary
- add /api/v1/fokabotDirectMessage for authenticated internal Aika DMs
- send the message to all active sessions for the target user
- return whether the user was online and how many sessions received it

## Testing
- cargo fmt
- cargo check