### PR TITLE
Report in-game match ID from mp make

### DIFF
--- a/src/commands/mp.rs
+++ b/src/commands/mp.rs
@@ -278,7 +278,7 @@ pub async fn make<C: Context>(ctx: &C, sender: &Session, args: MakeArgs) -> Comm
 
     Ok(Some(format!(
         "Tourney match created with ID {}.",
-        mp_match.match_id
+        mp_match.ingame_match_id()
     )))
 }
 


### PR DESCRIPTION
## Summary

- report `ingame_match_id()` from `!mp make` instead of the durable database ID

## Why

Tournament staff enter this value into the tournament client. After match IDs exceeded 65,535, the command reported the durable ID while the client expected its lower-16-bit in-game representation.

## Verification

- `cargo fmt --all -- --check`
- `cargo test --workspace` (2 passed)
- `git diff --check`
